### PR TITLE
fix crash when find the map's element which its defination in other f…

### DIFF
--- a/go/types/types.go
+++ b/go/types/types.go
@@ -222,7 +222,6 @@ func exprType(n ast.Node, expectTuple bool, pkg string, importer Importer) (xobj
 			_, t := exprType(expr, false, pkg, importer)
 			if t.Kind == ast.Typ {
 				debugp("expected value, got type %v", t)
-				t = badType
 			}
 			return obj, t
 
@@ -293,7 +292,7 @@ func exprType(n ast.Node, expectTuple bool, pkg string, importer Importer) (xobj
 			return nil, certify(n.Elt, ast.Var, t.Pkg, importer)
 		case *ast.MapType:
 			t := certify(n.Value, ast.Var, t.Pkg, importer)
-			if expectTuple {
+			if expectTuple && t.Kind != ast.Bad {
 				return nil, Type{MultiValue{[]ast.Expr{t.Node.(ast.Expr), predecl("bool")}}, ast.Var, t.Pkg}
 			}
 			return nil, t

--- a/godef.go
+++ b/godef.go
@@ -120,7 +120,7 @@ func main() {
 	case ast.Expr:
 		if !*tflag {
 			// try local declarations only
-			if obj, typ := types.ExprType(e, types.DefaultImporter); obj != nil {
+			if obj, typ := types.ExprType(e, types.DefaultImporter); obj != nil && typ.Kind != ast.Bad {
 				done(obj, typ)
 			}
 		}


### PR DESCRIPTION
when we find a map's element which its defination is located in another file,
it will crash.

Signed-off-by: Tw <tw19881113@gmail.com>