### PR TITLE
Don't panic on malformed code

### DIFF
--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -172,7 +172,7 @@ func (p *parser) declare1(decl ast.Node, scope *ast.Scope, kind ast.ObjKind, ide
 				case *ast.StarExpr:
 					rt = t.X.(*ast.Ident).Obj
 				default:
-					panic(fmt.Errorf("unknown type %T (%#v)", t, t))
+					return
 				}
 				if rt.Type == nil {
 					rt.Type = p.newScope(nil)


### PR DESCRIPTION
When using the parser programmatically on a collection of Go source files (for example to search for references to a symbol), I am seeing at least one case where the parser panics instead of just reporting errors.

The testdata in `github.com/golang/lint` triggers this panic.

```go
package main

import (
	"os"
	"path"

	"github.com/rogpeppe/godef/go/parser"
	"github.com/rogpeppe/godef/go/types"
)

func main() {
	filter := func(fi os.FileInfo) bool {
		return path.Ext(fi.Name()) == ".go"
	}
	parser.ParseDir(types.FileSet, "/go/src/github.com/golang/lint/testdata", filter, 0)
}
```

Result:

```
panic: unknown type *ast.BadExpr (&ast.BadExpr{From:5422, To:5422})

goroutine 1 [running]:
github.com/rogpeppe/godef/go/parser.(*parser).declare1(0xc820089b80, 0x50f470, 0xc820015b90, 0xc82000aa70, 0x5, 0xc82000ff40)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/parser.go:175 +0x90b
github.com/rogpeppe/godef/go/parser.(*parser).declare(0xc820089b80, 0x50f470, 0xc820015b90, 0xc82000bca0, 0x5, 0xc8200c7a78, 0x1, 0x1)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/parser.go:151 +0x13e
github.com/rogpeppe/godef/go/parser.(*parser).parseFuncDecl(0xc820089b80, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/parser.go:2155 +0x451
github.com/rogpeppe/godef/go/parser.(*parser).parseDecl(0xc820089b80, 0x0, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/parser.go:2178 +0x12e
github.com/rogpeppe/godef/go/parser.(*parser).parseFile(0xc820089b80, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/parser.go:2242 +0x26f
github.com/rogpeppe/godef/go/parser.ParseFile(0xc820010640, 0xc820010d00, 0x40, 0x164860, 0xc82000fea0, 0x0, 0xc82000aa70, 0xc820017180, 0x0, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/interface.go:149 +0x190
github.com/rogpeppe/godef/go/parser.parseFileInPkg(0xc820010640, 0xc820014a50, 0xc820010d00, 0x40, 0x0, 0x0, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/interface.go:169 +0x3bc
github.com/rogpeppe/godef/go/parser.ParseFiles(0xc820010640, 0xc8200a61e0, 0x1e, 0x1e, 0x0, 0xc820014a50, 0x0, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/interface.go:189 +0x117
github.com/rogpeppe/godef/go/parser.ParseDir(0xc820010640, 0x2362e0, 0x36, 0x24bb88, 0x0, 0x0, 0x0, 0x0)
	/Users/lukeh/dd/go/src/github.com/rogpeppe/godef/go/parser/interface.go:229 +0x2c4
main.main()
	/Users/lukeh/dd/go/src/github.com/lukehoban/azuretest/other.go:15 +0x4d
exit status 2
```