### PR TITLE
do not exclude "*_test.go" files from DefaultImporter

### DIFF
--- a/go/types/types.go
+++ b/go/types/types.go
@@ -106,12 +106,9 @@ func DefaultImporter(path string) *ast.Package {
 
 // isGoFile returns true if we will consider the file as a
 // possible candidate for parsing as part of a package.
-// Including _test.go here isn't quite right, but what
-// else can we do?
 //
 func isGoFile(d os.FileInfo) bool {
 	return strings.HasSuffix(d.Name(), ".go") &&
-		!strings.HasSuffix(d.Name(), "_test.go") &&
 		!strings.HasPrefix(d.Name(), ".") &&
 		goodOSArch(d.Name())
 }


### PR DESCRIPTION
This fixes problem that definitions from export_test.go are not found.