### PR TITLE
always use correct package identifiers rather than guessing

### DIFF
--- a/go/parser/parser_test.go
+++ b/go/parser/parser_test.go
@@ -25,7 +25,7 @@ var illegalInputs = []interface{}{
 
 func TestParseIllegalInputs(t *testing.T) {
 	for _, src := range illegalInputs {
-		_, err := ParseFile(fset, "", src, 0, nil)
+		_, err := ParseFile(fset, "", src, 0, nil, naiveImportPathToName)
 		if err == nil {
 			t.Errorf("ParseFile(%v) should have failed", src)
 		}
@@ -56,7 +56,7 @@ var validPrograms = []interface{}{
 
 func TestParseValidPrograms(t *testing.T) {
 	for _, src := range validPrograms {
-		_, err := ParseFile(fset, "", src, Trace, nil)
+		_, err := ParseFile(fset, "", src, Trace, nil, naiveImportPathToName)
 		if err != nil {
 			t.Errorf("ParseFile(%q): %v", src, err)
 		}
@@ -70,7 +70,7 @@ var validFiles = []string{
 
 func TestParse3(t *testing.T) {
 	for _, filename := range validFiles {
-		_, err := ParseFile(fset, filename, nil, DeclarationErrors, nil)
+		_, err := ParseFile(fset, filename, nil, DeclarationErrors, nil, nil)
 		if err != nil {
 			t.Errorf("ParseFile(%s): %v", filename, err)
 		}
@@ -92,7 +92,7 @@ func dirFilter(f os.FileInfo) bool { return nameFilter(f.Name()) }
 
 func TestParse4(t *testing.T) {
 	path := "."
-	pkgs, err := ParseDir(fset, path, dirFilter, 0)
+	pkgs, err := ParseDir(fset, path, dirFilter, 0, naiveImportPathToName)
 	if err != nil {
 		t.Fatalf("ParseDir(%s): %v", path, err)
 	}

--- a/go/printer/performance_test.go
+++ b/go/printer/performance_test.go
@@ -35,7 +35,7 @@ func initialize() {
 		log.Fatalf("%s", err)
 	}
 
-	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments, nil)
+	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments, nil, nil)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/go/printer/printer_test.go
+++ b/go/printer/printer_test.go
@@ -43,7 +43,7 @@ const (
 
 func runcheck(t *testing.T, source, golden string, mode checkMode) {
 	// parse source
-	prog, err := parser.ParseFile(fset, source, nil, parser.ParseComments, nil)
+	prog, err := parser.ParseFile(fset, source, nil, parser.ParseComments, nil, nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -172,7 +172,7 @@ func TestLineComments(t *testing.T) {
 	`
 
 	fset := token.NewFileSet()
-	ast1, err1 := parser.ParseFile(fset, "", src, parser.ParseComments, nil)
+	ast1, err1 := parser.ParseFile(fset, "", src, parser.ParseComments, nil, nil)
 	if err1 != nil {
 		panic(err1)
 	}

--- a/go/types/types.go
+++ b/go/types/types.go
@@ -85,7 +85,7 @@ func DefaultImporter(path string, srcDir string) *ast.Package {
 	if err != nil {
 		return nil
 	}
-	pkgs, err := parser.ParseDir(FileSet, bpkg.Dir, isGoFile, 0)
+	pkgs, err := parser.ParseDir(FileSet, bpkg.Dir, isGoFile, 0, DefaultImportPathToName)
 	if err != nil {
 		if Debug {
 			switch err := err.(type) {
@@ -106,6 +106,13 @@ func DefaultImporter(path string, srcDir string) *ast.Package {
 		debugp("package not found by ParseDir!")
 	}
 	return nil
+}
+
+// DefaultImportPathToName returns the package identifier
+// for the given import path.
+func DefaultImportPathToName(path, srcDir string) (string, error) {
+	pkg, err := build.Default.Import(path, srcDir, 0)
+	return pkg.Name, err
 }
 
 // isGoFile returns true if we will consider the file as a

--- a/go/types/types_test.go
+++ b/go/types/types_test.go
@@ -34,7 +34,7 @@ func (f astVisitor) Visit(n ast.Node) ast.Visitor {
 }
 
 func parseDir(dir string) *ast.Package {
-	pkgs, _ := parser.ParseDir(FileSet, dir, isGoFile, 0)
+	pkgs, _ := parser.ParseDir(FileSet, dir, isGoFile, 0, DefaultImportPathToName)
 	if len(pkgs) == 0 {
 		return nil
 	}
@@ -178,7 +178,7 @@ func TestCompile(t *testing.T) {
 func TestOneFile(t *testing.T) {
 	code, offsetMap := translateSymbols(testCode)
 	//fmt.Printf("------------------- {%s}\n", code)
-	f, err := parser.ParseFile(FileSet, "xx.go", code, 0, ast.NewScope(parser.Universe))
+	f, err := parser.ParseFile(FileSet, "xx.go", code, 0, ast.NewScope(parser.Universe), DefaultImportPathToName)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}


### PR DESCRIPTION
This will slow things down a little because we will always read
the directories of the imports of a file when parsing, but
hopefully won't make things *that* much slower.