### PR TITLE
go/types: remove unused GoPath definition

### DIFF
--- a/go/types/types.go
+++ b/go/types/types.go
@@ -75,9 +75,6 @@ type Importer func(path string, srcDir string) *ast.Package
 // When DefaultImporter is called, it adds any files to FileSet.
 var FileSet = token.NewFileSet()
 
-// GoPath is used by DefaultImporter to find packages.
-var GoPath = []string{filepath.Join(os.Getenv("GOROOT"), "src", "pkg")}
-
 // DefaultImporter looks for the package; if it finds it,
 // it parses and returns it. If no package was found, it returns nil.
 func DefaultImporter(path string, srcDir string) *ast.Package {

--- a/godef.go
+++ b/godef.go
@@ -35,23 +35,6 @@ func fail(s string, a ...interface{}) {
 	os.Exit(2)
 }
 
-func init() {
-	// take GOPATH, set types.GoPath to it if it's not empty.
-	p := os.Getenv("GOPATH")
-	if p == "" {
-		return
-	}
-	gopath := strings.Split(p, ":")
-	for i, d := range gopath {
-		gopath[i] = filepath.Join(d, "src")
-	}
-	r := runtime.GOROOT()
-	if r != "" {
-		gopath = append(gopath, r+"/src/pkg", r+"/src")
-	}
-	types.GoPath = gopath
-}
-
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: godef [flags] [expr]\n")


### PR DESCRIPTION
As pointed out by #30 