### PR TITLE
[master] Special treatment for "C" package.

### DIFF
--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -1967,6 +1967,9 @@ func parseImportSpec(p *parser, doc *ast.CommentGroup, decl *ast.GenDecl, _ int)
 		if declIdent == nil {
 			filename := p.fset.Position(path.Pos()).Filename
 			name, err := p.pathToName(litToString(path), filepath.Dir(filename))
+			if litToString(path) == "C" {
+				name = "C"
+			}
 			if name == "" {
 				p.error(path.Pos(), fmt.Sprintf("cannot find identifier for package %q: %v", litToString(path), err))
 			} else {


### PR DESCRIPTION
Fixes #41 (at least for me).

`import "C"` is not a real package. So `godef` cannot correctly parse any package that says `import "C"`. This adds a special treatment for this package and circumvents this problem.