### PR TITLE
go/parser: support type alias

### DIFF
--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -2028,6 +2028,9 @@ func parseTypeSpec(p *parser, doc *ast.CommentGroup, decl *ast.GenDecl, _ int) a
 	// containing block.
 	// (Global identifiers are resolved in a separate phase after parsing.)
 	spec := &ast.TypeSpec{doc, ident, nil, p.lineComment}
+	if p.tok == token.ASSIGN {
+		p.next()
+	}
 	p.declare(spec, p.topScope, ast.Typ, ident)
 	typ := p.parseType()
 	p.expectSemi() // call before accessing p.linecomment

--- a/go/parser/parser_test.go
+++ b/go/parser/parser_test.go
@@ -46,6 +46,7 @@ var validPrograms = []interface{}{
 	`package p; type T []int; var a []bool; func f() { if a[T{42}[0]] {} };`,
 	`package p; type T []int; func g(int) bool { return true }; func f() { if g(T{42}[0]) {} };`,
 	`package p; type T []int; func f() { for _ = range []int{T{42}[0]} {} };`,
+	`package p; type T = []int; func f() int { return T{42}[0] };`,
 	`package p; var a = T{{1, 2}, {3, 4}}`,
 	`package p; func f() { select { case <- c: case c <- d: case c <- <- d: case <-c <- d: } };`,
 	`package p; func f() { if ; true {} };`,


### PR DESCRIPTION
Support finding symbal in the package which has type alias defination in.