### PR TITLE
Fix the indentation

### DIFF
--- a/godef.go
+++ b/godef.go
@@ -232,7 +232,7 @@ func done(obj *ast.Object, typ types.Type) {
 	if typ.Kind == ast.Bad || !*tflag {
 		return
 	}
-	fmt.Printf("%s\n", strings.Replace(typeStr(obj, typ), "\n", "\n\t", -1))
+	fmt.Printf("%s\n", typeStr(obj, typ))
 	if *aflag || *Aflag {
 		var m orderedObjects
 		for obj := range typ.Iter() {


### PR DESCRIPTION
I found an extra indentation as below:
```
cat $GOPATH/src/github.com/rogpeppe/godef/acme.go|godef -t -i -f $GOPATH/src/github.com/rogpeppe/godef/acme.go -o 112 -a
/Users/uudashr/go/src/github.com/rogpeppe/godef/acme.go:14:6
type acmeFile struct {
		name		string
		body		[]byte
		offset		int
		runeOffset	int
	}
```

After fix:
```
cat $GOPATH/src/github.com/rogpeppe/godef/acme.go|godef -t -i -f $GOPATH/src/github.com/rogpeppe/godef/acme.go -o 112 -a
/Users/uudashr/go/src/github.com/rogpeppe/godef/acme.go:14:6
type acmeFile struct {
	name		string
	body		[]byte
	offset		int
	runeOffset	int
}
```
---
I don't know what the real intention, is it:
```
type acmeFile struct {
	name		string
	body		[]byte
	offset		int
	runeOffset	int
}
```

or all indented:
```
  type acmeFile struct {
  	name		string
  	body		[]byte
  	offset		int
  	runeOffset	int
  }
```