### PR TITLE
Initial cut of vgo-aware godef

### DIFF
--- a/godef.go
+++ b/godef.go
@@ -71,6 +71,24 @@ func main() {
 		}
 		src = b
 	}
+
+	// are we in vgo-mode?
+	fDir := filepath.Dir(filename)
+	dir := filepath.Dir(fDir)
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil && !fi.IsDir() {
+			if err := types.VgoInit(fDir); err != nil {
+				fail("cannot init vgo in dir %v: %v", fDir, err)
+			}
+			break
+		}
+		d, _ := filepath.Split(dir)
+		if d == dir {
+			break
+		}
+		dir = d
+	}
+
 	pkgScope := ast.NewScope(parser.Universe)
 	f, err := parser.ParseFile(types.FileSet, filename, src, 0, pkgScope, types.DefaultImportPathToName)
 	if f == nil {


### PR DESCRIPTION
**DO NOT MERGE**

Pushing up an initial cut to make `godef` [`vgo`](https://github.com/golang/go/issues/24301)-aware

To try this out locally:

```
cd $(go list -f "{{.Dir}}" github.com/rogpeppe/godef)
git fetch origin refs/pull/80/head:pr_80
git checkout pr_80
go install
```