### PR TITLE
Adding tests for godef

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/rogpeppe/godef
 
-require 9fans.net/go v0.0.0-20150709035532-65b8cf069318
+require (
+	9fans.net/go v0.0.0-20150709035532-65b8cf069318
+	golang.org/x/tools v0.0.0-20181113152950-150d8ac28524
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 9fans.net/go v0.0.0-20150709035532-65b8cf069318 h1:4UUc7iNL+A0hANTm+yo77gEMPecjhWYTepbDJUVY6Sg=
 9fans.net/go v0.0.0-20150709035532-65b8cf069318/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
+golang.org/x/tools v0.0.0-20181113152950-150d8ac28524 h1:L+vleGvDV0Yhxjny4yPmhu8kphkBTQGuhgOuNXdEUY8=
+golang.org/x/tools v0.0.0-20181113152950-150d8ac28524/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/godef_test.go
+++ b/godef_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"go/build"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/godef/go/types"
+	"golang.org/x/tools/go/packages/packagestest"
+)
+
+func TestGoDef(t *testing.T) { packagestest.TestAll(t, testGoDef) }
+func testGoDef(t *testing.T, exporter packagestest.Exporter) {
+	const godefAction = ">"
+	modules := []packagestest.Module{{
+		Name:  "github.com/rogpeppe/godef",
+		Files: packagestest.MustCopyFileTree("testdata"),
+	}}
+	exported := packagestest.Export(t, exporter, modules)
+	defer exported.Cleanup()
+
+	posStr := func(p token.Position) string {
+		return localPos(p, exported, modules)
+	}
+
+	const gopathPrefix = "GOPATH="
+	const gorootPrefix = "GOROOT="
+	for _, v := range exported.Config.Env {
+		if strings.HasPrefix(v, gopathPrefix) {
+			build.Default.GOPATH = v[len(gopathPrefix):]
+		}
+		if strings.HasPrefix(v, gorootPrefix) {
+			build.Default.GOROOT = v[len(gorootPrefix):]
+		}
+	}
+
+	count := 0
+	exported.Expect(map[string]interface{}{
+		"godef": func(src, target token.Position) {
+			count++
+			input, err := ioutil.ReadFile(src.Filename)
+			if err != nil {
+				t.Errorf("Failed %v: %v", src, err)
+				return
+			}
+			// There's a "saved" version of the file, so
+			// copy it to the original version; we want the
+			// Expect method to see the in-editor-buffer
+			// versions of the files, but we want the godef
+			// function to see the files as they should
+			// be on disk, so that we're actually testing the
+			// define-in-buffer functionality.
+			savedFile := src.Filename + ".saved"
+			if _, err := os.Stat(savedFile); err == nil {
+				savedData, err := ioutil.ReadFile(savedFile)
+				if err != nil {
+					t.Fatalf("cannot read saved file: %v", err)
+				}
+				if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
+					t.Fatalf("cannot write saved file: %v", err)
+				}
+				defer ioutil.WriteFile(src.Filename, input, 0666)
+			}
+			obj, _, err := godef(src.Filename, input, src.Offset)
+			if err != nil {
+				t.Errorf("Failed %v: %v", src, err)
+				return
+			}
+			pos := types.FileSet.Position(types.DeclPos(obj))
+			check := token.Position{
+				Filename: pos.Filename,
+				Line:     pos.Line,
+				Column:   pos.Column,
+				Offset:   pos.Offset,
+			}
+			if posStr(check) != posStr(target) {
+				t.Errorf("Got %v expected %v", posStr(check), posStr(target))
+			}
+		},
+	})
+	if count == 0 {
+		t.Fatalf("No godef tests were run")
+	}
+}
+
+var cwd, _ = os.Getwd()
+
+func localPos(pos token.Position, e *packagestest.Exported, modules []packagestest.Module) string {
+	fstat, fstatErr := os.Stat(pos.Filename)
+	if fstatErr != nil {
+		return pos.String()
+	}
+	for _, m := range modules {
+		for fragment := range m.Files {
+			fname := e.File(m.Name, fragment)
+			if s, err := os.Stat(fname); err == nil && os.SameFile(s, fstat) {
+				pos.Filename = filepath.Join(cwd, "testdata", filepath.FromSlash(fragment))
+				return pos.String()
+			}
+		}
+	}
+	return pos.String()
+}
+

--- a/testdata/a/a.go
+++ b/testdata/a/a.go
@@ -1,0 +1,10 @@
+// A comment just to push the positions out
+
+package a
+
+func Stuff() { //@Stuff
+	x := 5
+	Random2(x) //@godef("dom2", Random2)
+	Random()   //@godef("()", Random)
+}
+

--- a/testdata/a/random.go
+++ b/testdata/a/random.go
@@ -1,0 +1,24 @@
+package a
+
+func Random() int { //@Random
+	y := 6 + 7
+	return y
+}
+
+func Random2(y int) int { //@Random2,mark(RandomParamY, "y")
+	return y //@godef("y", RandomParamY)
+}
+
+type Pos struct {
+	x, y int //@mark(PosX, "x"),mark(PosY, "y")
+}
+
+func (p *Pos) Sum() int { //@mark(PosSum, "Sum")
+	return p.x + p.y //@godef("x", PosX)
+}
+
+func _() {
+	var p Pos
+	_ = p.Sum() //@godef("()", PosSum)
+}
+

--- a/testdata/b/b.go
+++ b/testdata/b/b.go
@@ -1,0 +1,22 @@
+package b
+
+import "github.com/rogpeppe/godef/a"
+
+type S1 struct { //@S1
+	F1 int //@mark(S1F1, "F1")
+	S2     //@godef("S2", S2), mark(S1S2, "S2")
+}
+
+type S2 struct { //@S2
+	F1 string //@mark(S2F1, "F1")
+	F2 int    //@mark(S2F2, "F2")
+}
+
+func Bar() {
+	a.Stuff() //@godef("Stuff", Stuff)
+	var x S1  //@godef("S1", S1)
+	x.S2      //@godef("S2", S1S2)
+	x.F1      //@godef("F1", S1F1)
+	x.F2      //@godef("F2", S2F2)
+	x.S2.F1   //@godef("F1", S2F1)
+}

--- a/testdata/b/c.go
+++ b/testdata/b/c.go
@@ -1,0 +1,8 @@
+package b
+
+// This is the in-editor version of the file.
+// The on-disk version is in c.go.saved.
+
+var _ = S1{ //@godef("S1", S1)
+	F1: 99, //@_godef("F1", S1F1) //disabled, godef cannot resolve struct literal fields yet
+}

--- a/testdata/b/c.go.saved
+++ b/testdata/b/c.go.saved
@@ -1,0 +1,7 @@
+package b
+
+// This is the on-disk version of c.go, which represents
+// the in-editor version of the file.
+
+}
+

--- a/testdata/broken/unclosedIf.go
+++ b/testdata/broken/unclosedIf.go
@@ -1,0 +1,10 @@
+package broken
+
+import "fmt"
+
+func unclosedIf() {
+	if BadExpr {
+		var myUnclosedIf string               //@myUnclosedIf
+		fmt.Println("s = %v\n", myUnclosedIf) //@godef("my", myUnclosedIf)
+}
+


### PR DESCRIPTION
This uses the new testing framework from go/packages, but does not actually use
go/packages itself.
These tests are intended to check the basic functionality of godef, and should
remain stable across the implementation change to come.