### PR TITLE
Adding benchmarks and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,5 @@ module github.com/rogpeppe/godef
 
 require (
 	9fans.net/go v0.0.0-20181112161441-237454027057
-	golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea
+	golang.org/x/tools v0.0.0-20181130195746-895048a75ecf
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rogpeppe/godef
 
 require (
-	9fans.net/go v0.0.0-20150709035532-65b8cf069318
-	golang.org/x/tools v0.0.0-20181113152950-150d8ac28524
+	9fans.net/go v0.0.0-20181112161441-237454027057
+	golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
 9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
-golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea h1:IgBRaAk+MbtZlVmfNKPNabLl3nuwVkFJvHaVVOGfaBE=
-golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181130195746-895048a75ecf h1:1efYtlcDNt7EL138lS6P4KphZ1KEMWvhFa3FsLbTWEY=
+golang.org/x/tools v0.0.0-20181130195746-895048a75ecf/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-9fans.net/go v0.0.0-20150709035532-65b8cf069318 h1:4UUc7iNL+A0hANTm+yo77gEMPecjhWYTepbDJUVY6Sg=
-9fans.net/go v0.0.0-20150709035532-65b8cf069318/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
-golang.org/x/tools v0.0.0-20181113152950-150d8ac28524 h1:L+vleGvDV0Yhxjny4yPmhu8kphkBTQGuhgOuNXdEUY8=
-golang.org/x/tools v0.0.0-20181113152950-150d8ac28524/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
+9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
+golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea h1:IgBRaAk+MbtZlVmfNKPNabLl3nuwVkFJvHaVVOGfaBE=
+golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/godef_test.go
+++ b/godef_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"go/build"
 	"go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -50,40 +53,13 @@ func runGoDefTest(t testing.TB, exporter packagestest.Exporter, runCount int, mo
 	}
 
 	count := 0
-	exported.Expect(map[string]interface{}{
+	if err := exported.Expect(map[string]interface{}{
 		"godef": func(src, target token.Position) {
 			count++
-			input, err := ioutil.ReadFile(src.Filename)
+			obj, _, err := invokeGodef(src, runCount)
 			if err != nil {
-				t.Errorf("Failed %v: %v", src, err)
+				t.Error(err)
 				return
-			}
-			// There's a "saved" version of the file, so
-			// copy it to the original version; we want the
-			// Expect method to see the in-editor-buffer
-			// versions of the files, but we want the godef
-			// function to see the files as they should
-			// be on disk, so that we're actually testing the
-			// define-in-buffer functionality.
-			savedFile := src.Filename + ".saved"
-			if _, err := os.Stat(savedFile); err == nil {
-				savedData, err := ioutil.ReadFile(savedFile)
-				if err != nil {
-					t.Fatalf("cannot read saved file: %v", err)
-				}
-				if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
-					t.Fatalf("cannot write saved file: %v", err)
-				}
-				defer ioutil.WriteFile(src.Filename, input, 0666)
-			}
-			// repeat the actual godef part n times, for benchmark support
-			var obj *ast.Object
-			for i := 0; i < runCount; i++ {
-				obj, _, err = godef(src.Filename, input, src.Offset)
-				if err != nil {
-					t.Errorf("Failed %v: %v", src, err)
-					return
-				}
 			}
 			pos := types.FileSet.Position(types.DeclPos(obj))
 			check := token.Position{
@@ -96,13 +72,88 @@ func runGoDefTest(t testing.TB, exporter packagestest.Exporter, runCount int, mo
 				t.Errorf("Got %v expected %v", posStr(check), posStr(target))
 			}
 		},
-	})
+		"godefPrint": func(src token.Position, mode string, re *regexp.Regexp) {
+			count++
+			obj, typ, err := invokeGodef(src, runCount)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			buf := &bytes.Buffer{}
+			switch mode {
+			case "json":
+				*jsonFlag = true
+				*tflag = false
+				*aflag = false
+				*Aflag = false
+			case "all":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = true
+				*Aflag = true
+			case "public":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = true
+				*Aflag = false
+			case "type":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = false
+				*Aflag = false
+			default:
+				t.Fatalf("Invalid print mode %v", mode)
+			}
+
+			print(buf, obj, typ)
+			if !re.Match(buf.Bytes()) {
+				t.Errorf("in mode %q got %v want %v", mode, buf, re)
+			}
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if count == 0 {
 		t.Fatalf("No godef tests were run")
 	}
 }
 
 var cwd, _ = os.Getwd()
+
+func invokeGodef(src token.Position, runCount int) (*ast.Object, types.Type, error) {
+	input, err := ioutil.ReadFile(src.Filename)
+	if err != nil {
+		return nil, types.Type{}, fmt.Errorf("Failed %v: %v", src, err)
+	}
+	// There's a "saved" version of the file, so
+	// copy it to the original version; we want the
+	// Expect method to see the in-editor-buffer
+	// versions of the files, but we want the godef
+	// function to see the files as they should
+	// be on disk, so that we're actually testing the
+	// define-in-buffer functionality.
+	savedFile := src.Filename + ".saved"
+	if _, err := os.Stat(savedFile); err == nil {
+		savedData, err := ioutil.ReadFile(savedFile)
+		if err != nil {
+			return nil, types.Type{}, fmt.Errorf("cannot read saved file: %v", err)
+		}
+		if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
+			return nil, types.Type{}, fmt.Errorf("cannot write saved file: %v", err)
+		}
+		defer ioutil.WriteFile(src.Filename, input, 0666)
+	}
+	// repeat the actual godef part n times, for benchmark support
+	var obj *ast.Object
+	var typ types.Type
+	for i := 0; i < runCount; i++ {
+		obj, typ, err = godef(src.Filename, input, src.Offset)
+		if err != nil {
+			return nil, types.Type{}, fmt.Errorf("Failed %v: %v", src, err)
+		}
+	}
+	return obj, typ, nil
+}
 
 func localPos(pos token.Position, e *packagestest.Exported, modules []packagestest.Module) string {
 	fstat, fstatErr := os.Stat(pos.Filename)

--- a/testdata/b/b.go
+++ b/testdata/b/b.go
@@ -4,6 +4,8 @@ import "github.com/rogpeppe/godef/a"
 
 type S1 struct { //@S1
 	F1 int //@mark(S1F1, "F1")
+	f2 int
+	f3 S2
 	S2     //@godef("S2", S2), mark(S1S2, "S2")
 }
 

--- a/testdata/print/print.go
+++ b/testdata/print/print.go
@@ -1,0 +1,83 @@
+package print
+
+import (
+	"github.com/rogpeppe/godef/a"
+	"github.com/rogpeppe/godef/b"
+)
+
+type localStruct struct {
+	Exported bool
+	private  bool
+}
+
+func printing() {
+start:
+	var thing localStruct
+	if thing.private {
+		thing.Exported = false
+		goto start //@mark(PrintStart, "start")
+	}
+	a.Stuff()    //@mark(PrintA, "a"),mark(PrintStuff, "Stuff")
+	var _ = b.S1 //@mark(PrintS1, "S1")
+	const c1 = 5
+	if c1 == 2 { //@mark(PrintC1, "c1")
+	}
+
+	/*@
+	godefPrint(PrintA, "json", re`^(|
+		){"filename":".*godef.print.print\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintA, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)import \(a "github\.com/rogpeppe/godef/a"\)\n$`)
+
+	godefPrint(PrintStuff, "json", re`^(|
+		){"filename":".*godef.a.a\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintStuff, "type", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+	godefPrint(PrintStuff, "public", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+	godefPrint(PrintStuff, "all", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+
+	godefPrint(PrintC1, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)const c1 int = 5\n$`)
+
+	godefPrint(PrintStart, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)label start\n$`)
+
+	godefPrint(PrintS1, "json", re`^(|
+		){"filename":".*godef.b.b\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintS1, "type", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct \{(\n|
+		)	F1	int(\n|
+		)	f2	int(\n|
+		)	f3	S2(\n|
+		)	S2(\n|
+		)\}\n$`)
+	// this succeeds, but lists no fields which seems wrong
+	_godefPrint(PrintS1, "public", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct \{(\n|
+		)	F1	int(\n|
+		)	f2	int(\n|
+		)	f3	S2(\n|
+		)	S2(\n|
+		)\}\n$`)
+	// the following fails, but it lists F1 twice, once as 'F1 string' which is wrong
+	_godefPrint(PrintS1, "all", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct \{(\n|
+		)	F1	int(\n|
+		)	f2	int(\n|
+		)	f3	S2(\n|
+		)	S2(\n|
+		)\}\n$`)
+	*/
+}
+


### PR DESCRIPTION
The first commit in this chain was already up as a separate pull request, the second two are logically separate but it's probably easiest to just review them all together.

This adds some more tests, this time for the printed format of godef (rather than just the detection of the definition)
The tests right at the bottom of print.go are disabled because I don't think the current behavior is correct.
The first one prints no fields at all, instead of just the public fields, and the second one prints fields that do not exist.