### PR TITLE
Full module support

### DIFF
--- a/adapt.go
+++ b/adapt.go
@@ -1,0 +1,90 @@
+package main
+
+// The contents of this file are designed to adapt between the two implementations
+// of godef, and should be removed when we fully switch to the go/pacakges
+// implementation for all cases
+
+import (
+	"fmt"
+	"golang.org/x/tools/go/packages"
+	"sort"
+
+	rpast "github.com/rogpeppe/godef/go/ast"
+	rpprinter "github.com/rogpeppe/godef/go/printer"
+	rptypes "github.com/rogpeppe/godef/go/types"
+)
+
+func adaptGodef(cfg *packages.Config, filename string, src []byte, searchpos int) (*Object, error) {
+	obj, typ, err := godef(filename, src, searchpos)
+	if err != nil {
+		return nil, err
+	}
+	return adaptRPObject(obj, typ)
+}
+
+func adaptRPObject(obj *rpast.Object, typ rptypes.Type) (*Object, error) {
+	pos := rptypes.FileSet.Position(rptypes.DeclPos(obj))
+	result := &Object{
+		Name: obj.Name,
+		Pkg:  typ.Pkg,
+		Position: Position{
+			Filename: pos.Filename,
+			Line:     pos.Line,
+			Column:   pos.Column,
+		},
+		Type: typ,
+	}
+	switch obj.Kind {
+	case rpast.Bad:
+		result.Kind = BadKind
+	case rpast.Fun:
+		result.Kind = FuncKind
+	case rpast.Var:
+		result.Kind = VarKind
+	case rpast.Pkg:
+		result.Kind = ImportKind
+		result.Type = nil
+		result.Value = typ.Node.(*rpast.ImportSpec).Path.Value
+	case rpast.Con:
+		result.Kind = ConstKind
+		if decl, ok := obj.Decl.(*rpast.ValueSpec); ok {
+			result.Value = decl.Values[0]
+		}
+	case rpast.Lbl:
+		result.Kind = LabelKind
+		result.Type = nil
+	case rpast.Typ:
+		result.Kind = TypeKind
+		result.Type = typ.Underlying(false)
+	}
+	for child := range typ.Iter() {
+		m, err := adaptRPObject(child, rptypes.Type{})
+		if err != nil {
+			return nil, err
+		}
+		result.Members = append(result.Members, m)
+	}
+	sort.Sort(orderedObjects(result.Members))
+	return result, nil
+}
+
+type pretty struct {
+	n interface{}
+}
+
+func (p pretty) Format(f fmt.State, c rune) {
+	switch n := p.n.(type) {
+	case *rpast.BasicLit:
+		rpprinter.Fprint(f, rptypes.FileSet, n)
+	case rptypes.Type:
+		// TODO print path package when appropriate.
+		// Current issues with using p.n.Pkg:
+		//	- we should actually print the local package identifier
+		//	rather than the package path when possible.
+		//	- p.n.Pkg is non-empty even when
+		//	the type is not relative to the package.
+		rpprinter.Fprint(f, rptypes.FileSet, n.Node)
+	default:
+		fmt.Fprint(f, n)
+	}
+}

--- a/adapt.go
+++ b/adapt.go
@@ -5,16 +5,72 @@ package main
 // implementation for all cases
 
 import (
+	"bufio"
+	"bytes"
+	"flag"
 	"fmt"
 	"golang.org/x/tools/go/packages"
+	"os"
+	"os/exec"
 	"sort"
+	"strconv"
+	"strings"
 
 	rpast "github.com/rogpeppe/godef/go/ast"
 	rpprinter "github.com/rogpeppe/godef/go/printer"
 	rptypes "github.com/rogpeppe/godef/go/types"
+
+	//goast "go/ast"
+	//goparser "go/parser"
+	//goprinter "go/printer"
+	gotoken "go/token"
+	gotypes "go/types"
 )
 
+var forcePackages triBool
+func init() {
+	flag.Var(&forcePackages, "force-packages", "force godef to use the go/packages implentation")
+}
+
+type triBool struct { value, set bool }
+func (b *triBool) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	b.set = true
+	b.value = v
+	return err
+}
+func (b *triBool) Get() interface{} {
+	if !b.set {
+		return "default"
+	}
+	return b.value
+}
+func (b *triBool) String() string {
+	if !b.set {
+		return "default"
+	}
+	return strconv.FormatBool(b.value)
+}
+func (b *triBool) IsBoolFlag() bool { return true }
+
 func adaptGodef(cfg *packages.Config, filename string, src []byte, searchpos int) (*Object, error) {
+	usePackages := forcePackages.value
+	if !forcePackages.set {
+		cmd := exec.Command("go", "env", "GOMOD")
+		cmd.Env = cfg.Env
+		cmd.Dir = cfg.Dir
+		out, err := cmd.Output()
+		if err == nil && len(strings.TrimSpace(string(out))) > 0 {
+			usePackages = true
+		}
+	}
+	if usePackages {
+		fset, obj, err := godefPackages(cfg, filename, src, searchpos)
+		if err != nil {
+			return nil, err
+		}
+		return adaptGoObject(fset, obj)
+	}
 	obj, typ, err := godef(filename, src, searchpos)
 	if err != nil {
 		return nil, err
@@ -68,6 +124,74 @@ func adaptRPObject(obj *rpast.Object, typ rptypes.Type) (*Object, error) {
 	return result, nil
 }
 
+func adaptGoObject(fset *gotoken.FileSet, obj gotypes.Object) (*Object, error) {
+	result := &Object{
+		Name: obj.Name(),
+		//Pkg:  typ.Pkg,
+		Position: objToPos(fset, obj),
+		Type: obj.Type(),
+	}
+	switch obj := obj.(type) {
+	case *gotypes.Func:
+		result.Kind = FuncKind
+	case *gotypes.Var:
+		result.Kind = VarKind
+	case *gotypes.PkgName:
+		result.Kind = ImportKind
+		result.Type = nil
+		result.Value = strconv.Quote(obj.Imported().Path())
+	case *gotypes.Const:
+		result.Kind = ConstKind
+	 	result.Value = obj.Val()
+	case *gotypes.Label:
+		result.Kind = LabelKind
+		result.Type = nil
+	case *gotypes.TypeName:
+		result.Kind = TypeKind
+		result.Type = obj.Type().Underlying()
+	default:
+		result.Kind = BadKind
+	}
+
+	return result, nil
+}
+
+func objToPos(fSet *gotoken.FileSet, obj gotypes.Object) Position {
+	p := obj.Pos()
+	f := fSet.File(p)
+	goPos := f.Position(p)
+	pos := Position{
+		Filename: goPos.Filename,
+		Line: goPos.Line,
+		Column: goPos.Column,
+	}
+	if pos.Column != 1 {
+		return pos
+	}
+	// currently exportdata does not store the column
+	// until it does, we have a hacky fix to attempt to find the name within
+	// the line and patch the column to match
+	named, ok := obj.(interface{ Name() string })
+	if !ok {
+		return pos
+	}
+	in, err := os.Open(f.Name())
+	if err != nil {
+		return pos
+	}
+	for l, scanner := 1, bufio.NewScanner(in); scanner.Scan(); l++ {
+		if l < pos.Line {
+			continue
+		}
+		col := bytes.Index([]byte(scanner.Text()), []byte(named.Name()))
+		if col >= 0 {
+			pos.Column = col + 1
+		}
+		break
+	}
+	return pos
+}
+
 type pretty struct {
 	n interface{}
 }
@@ -84,6 +208,10 @@ func (p pretty) Format(f fmt.State, c rune) {
 		//	- p.n.Pkg is non-empty even when
 		//	the type is not relative to the package.
 		rpprinter.Fprint(f, rptypes.FileSet, n.Node)
+	case gotypes.Type:
+		buf := &bytes.Buffer{}
+		gotypes.WriteType(buf, n, func(p *gotypes.Package) string { return ""} )
+		buf.WriteTo(f)
 	default:
 		fmt.Fprint(f, n)
 	}

--- a/adapt.go
+++ b/adapt.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -206,7 +207,7 @@ func objToPos(fSet *gotoken.FileSet, obj gotypes.Object) Position {
 	f := fSet.File(p)
 	goPos := f.Position(p)
 	pos := Position{
-		Filename: goPos.Filename,
+		Filename: cleanFilename(goPos.Filename),
 		Line:     goPos.Line,
 		Column:   goPos.Column,
 	}
@@ -235,6 +236,16 @@ func objToPos(fSet *gotoken.FileSet, obj gotypes.Object) Position {
 		break
 	}
 	return pos
+}
+
+// cleanFilename normalizes any file names that come out of the fileset.
+func cleanFilename(path string) string {
+	const prefix = "$GOROOT"
+	if !strings.EqualFold(prefix, path[:len(prefix)]) {
+		return path
+	}
+	//TODO: we need a better way to get the GOROOT that uses the packages api
+	return runtime.GOROOT() + path[len(prefix):]
 }
 
 type pretty struct {

--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,5 @@ module github.com/rogpeppe/godef
 
 require (
 	9fans.net/go v0.0.0-20181112161441-237454027057
-	golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea
+	golang.org/x/tools v0.0.0-20181130195746-895048a75ecf
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rogpeppe/godef
 
 require (
-	9fans.net/go v0.0.0-20150709035532-65b8cf069318
-	golang.org/x/tools v0.0.0-20181113152950-150d8ac28524
+	9fans.net/go v0.0.0-20181112161441-237454027057
+	golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
 9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
-golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea h1:IgBRaAk+MbtZlVmfNKPNabLl3nuwVkFJvHaVVOGfaBE=
-golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181130195746-895048a75ecf h1:1efYtlcDNt7EL138lS6P4KphZ1KEMWvhFa3FsLbTWEY=
+golang.org/x/tools v0.0.0-20181130195746-895048a75ecf/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-9fans.net/go v0.0.0-20150709035532-65b8cf069318 h1:4UUc7iNL+A0hANTm+yo77gEMPecjhWYTepbDJUVY6Sg=
-9fans.net/go v0.0.0-20150709035532-65b8cf069318/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
-golang.org/x/tools v0.0.0-20181113152950-150d8ac28524 h1:L+vleGvDV0Yhxjny4yPmhu8kphkBTQGuhgOuNXdEUY8=
-golang.org/x/tools v0.0.0-20181113152950-150d8ac28524/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
+9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
+golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea h1:IgBRaAk+MbtZlVmfNKPNabLl3nuwVkFJvHaVVOGfaBE=
+golang.org/x/tools v0.0.0-20181121192916-72292f0c83ea/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/godef.go
+++ b/godef.go
@@ -181,7 +181,7 @@ func godef(filename string, src []byte, searchpos int) (*ast.Object, types.Type,
 		if err != nil {
 			return nil, types.Type{}, fmt.Errorf("error finding import path for %s: %s", path, err)
 		}
-		fmt.Println(pkg.Dir)
+		return &ast.Object{Kind: ast.Pkg, Data: pkg.Dir}, types.Type{}, nil
 	case ast.Expr:
 		if !*tflag {
 			// try local declarations only
@@ -310,6 +310,7 @@ const (
 	ConstKind  Kind = "const"
 	LabelKind  Kind = "label"
 	TypeKind   Kind = "type"
+	PathKind   Kind = "path"
 )
 
 type Object struct {
@@ -329,6 +330,10 @@ func (o orderedObjects) Len() int           { return len(o) }
 func (o orderedObjects) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }
 
 func print(out io.Writer, obj *Object) error {
+	if obj.Kind == PathKind {
+		fmt.Fprintf(out, "%s\n", obj.Value)
+		return nil
+	}
 	if *jsonFlag {
 		jsonStr, err := json.Marshal(obj.Position)
 		if err != nil {

--- a/godef.go
+++ b/godef.go
@@ -367,7 +367,7 @@ func typeStr(obj *Object) string {
 	switch obj.Kind {
 	case VarKind, FuncKind:
 		// don't print these
-	case "import":
+	case ImportKind:
 		valueFmt = " %v)"
 		fmt.Fprint(buf, obj.Kind)
 		fmt.Fprint(buf, " (")

--- a/godef_test.go
+++ b/godef_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"go/build"
 	"go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -50,40 +53,13 @@ func runGoDefTest(t testing.TB, exporter packagestest.Exporter, runCount int, mo
 	}
 
 	count := 0
-	exported.Expect(map[string]interface{}{
+	if err := exported.Expect(map[string]interface{}{
 		"godef": func(src, target token.Position) {
 			count++
-			input, err := ioutil.ReadFile(src.Filename)
+			obj, _, err := invokeGodef(src, runCount)
 			if err != nil {
-				t.Errorf("Failed %v: %v", src, err)
+				t.Error(err)
 				return
-			}
-			// There's a "saved" version of the file, so
-			// copy it to the original version; we want the
-			// Expect method to see the in-editor-buffer
-			// versions of the files, but we want the godef
-			// function to see the files as they should
-			// be on disk, so that we're actually testing the
-			// define-in-buffer functionality.
-			savedFile := src.Filename + ".saved"
-			if _, err := os.Stat(savedFile); err == nil {
-				savedData, err := ioutil.ReadFile(savedFile)
-				if err != nil {
-					t.Fatalf("cannot read saved file: %v", err)
-				}
-				if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
-					t.Fatalf("cannot write saved file: %v", err)
-				}
-				defer ioutil.WriteFile(src.Filename, input, 0666)
-			}
-			// repeat the actual godef part n times, for benchmark support
-			var obj *ast.Object
-			for i := 0; i < runCount; i++ {
-				obj, _, err = godef(src.Filename, input, src.Offset)
-				if err != nil {
-					t.Errorf("Failed %v: %v", src, err)
-					return
-				}
 			}
 			pos := types.FileSet.Position(types.DeclPos(obj))
 			check := token.Position{
@@ -96,13 +72,88 @@ func runGoDefTest(t testing.TB, exporter packagestest.Exporter, runCount int, mo
 				t.Errorf("Got %v expected %v", posStr(check), posStr(target))
 			}
 		},
-	})
+		"godefPrint": func(src token.Position, mode string, re *regexp.Regexp) {
+			count++
+			obj, typ, err := invokeGodef(src, runCount)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			buf := &bytes.Buffer{}
+			switch mode {
+			case "json":
+				*jsonFlag = true
+				*tflag = false
+				*aflag = false
+				*Aflag = false
+			case "all":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = true
+				*Aflag = true
+			case "public":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = true
+				*Aflag = false
+			case "type":
+				*jsonFlag = false
+				*tflag = true
+				*aflag = false
+				*Aflag = false
+			default:
+				t.Fatalf("Invalid print mode %v", mode)
+			}
+
+			print(buf, obj, typ)
+			if !re.Match(buf.Bytes()) {
+				t.Errorf("in mode %q got %v want %v", mode, buf, re)
+			}
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if count == 0 {
 		t.Fatalf("No godef tests were run")
 	}
 }
 
 var cwd, _ = os.Getwd()
+
+func invokeGodef(src token.Position, runCount int) (*ast.Object, types.Type, error) {
+	input, err := ioutil.ReadFile(src.Filename)
+	if err != nil {
+		return nil, types.Type{}, fmt.Errorf("Failed %v: %v", src, err)
+	}
+	// There's a "saved" version of the file, so
+	// copy it to the original version; we want the
+	// Expect method to see the in-editor-buffer
+	// versions of the files, but we want the godef
+	// function to see the files as they should
+	// be on disk, so that we're actually testing the
+	// define-in-buffer functionality.
+	savedFile := src.Filename + ".saved"
+	if _, err := os.Stat(savedFile); err == nil {
+		savedData, err := ioutil.ReadFile(savedFile)
+		if err != nil {
+			return nil, types.Type{}, fmt.Errorf("cannot read saved file: %v", err)
+		}
+		if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
+			return nil, types.Type{}, fmt.Errorf("cannot write saved file: %v", err)
+		}
+		defer ioutil.WriteFile(src.Filename, input, 0666)
+	}
+	// repeat the actual godef part n times, for benchmark support
+	var obj *ast.Object
+	var typ types.Type
+	for i := 0; i < runCount; i++ {
+		obj, typ, err = godef(src.Filename, input, src.Offset)
+		if err != nil {
+			return nil, types.Type{}, fmt.Errorf("Failed %v: %v", src, err)
+		}
+	}
+	return obj, typ, nil
+}
 
 func localPos(pos token.Position, e *packagestest.Exported, modules []packagestest.Module) string {
 	fstat, fstatErr := os.Stat(pos.Filename)

--- a/packages.go
+++ b/packages.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
+)
+
+func godefPackages(cfg *packages.Config, filename string, src []byte, searchpos int) (*token.FileSet, types.Object, error) {
+	parser, result := parseFile(filename, searchpos)
+	// Load, parse, and type-check the packages named on the command line.
+	if src != nil {
+		cfg.Overlay = map[string][]byte{
+			filename: src,
+		}
+	}
+	cfg.Mode = packages.LoadSyntax
+	cfg.ParseFile = parser
+	lpkgs, err := packages.Load(cfg, "file="+filename)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(lpkgs) < 1 {
+		return nil, nil, fmt.Errorf("There must be at least one package that contains the file")
+	}
+	// get the node
+	var m match
+	select {
+	case m = <-result:
+	default:
+		return nil, nil, fmt.Errorf("no file found at search pos %d", searchpos)
+	}
+	if m.ident == nil {
+		return nil, nil, fmt.Errorf("Offset %d was not a valid identifier", searchpos)
+	}
+	obj := lpkgs[0].TypesInfo.ObjectOf(m.ident)
+	if obj == nil {
+		return nil, nil, fmt.Errorf("no object")
+	}
+	if m.wasEmbeddedField {
+		// the original position was on the embedded field declaration
+		// so we try to dig out the type and jump to that instead
+		if v, ok := obj.(*types.Var); ok {
+			if n, ok := v.Type().(*types.Named); ok {
+				obj = n.Obj()
+			}
+		}
+	}
+	return lpkgs[0].Fset, obj, nil
+}
+
+// match returns the ident plus any extra information needed
+type match struct {
+	ident            *ast.Ident
+	wasEmbeddedField bool
+}
+
+// parseFile returns a function that can be used as a Parser in packages.Config.
+// It replaces the contents of a file that matches filename with the src.
+// It also drops all function bodies that do not contain the searchpos.
+// It also modifies the filename to be the canonical form that will appear in the fileset.
+func parseFile(filename string, searchpos int) (func(*token.FileSet, string, []byte) (*ast.File, error), chan match) {
+	result := make(chan match, 1)
+	isInputFile := newFileCompare(filename)
+	return func(fset *token.FileSet, fname string, filedata []byte) (*ast.File, error) {
+		isInput := isInputFile(fname)
+		file, err := parser.ParseFile(fset, fname, filedata, 0)
+		if file == nil {
+			return nil, err
+		}
+		pos := token.Pos(-1)
+		if isInput {
+			tfile := fset.File(file.Pos())
+			if tfile == nil {
+				return file, fmt.Errorf("cursor %d is beyond end of file %s (%d)", searchpos, fname, file.End()-file.Pos())
+			}
+			if searchpos > tfile.Size() {
+				return file, fmt.Errorf("cursor %d is beyond end of file %s (%d)", searchpos, fname, tfile.Size())
+			}
+			pos = tfile.Pos(searchpos)
+			m, err := findMatch(file, pos)
+			if err != nil {
+				return nil, err
+			}
+			result <- m
+		}
+		trimAST(file, pos)
+		return file, err
+	}, result
+}
+
+func newFileCompare(filename string) func(string) bool {
+	fstat, fstatErr := os.Stat(filename)
+	return func(compare string) bool {
+		if filename == compare {
+			return true
+		}
+		if fstatErr != nil {
+			return false
+		}
+		if s, err := os.Stat(compare); err == nil {
+			return os.SameFile(fstat, s)
+		}
+		return false
+	}
+}
+
+func findMatch(f *ast.File, pos token.Pos) (match, error) {
+	m, err := checkMatch(f, pos)
+	if err != nil {
+		return match{}, err
+	}
+	if m.ident != nil {
+		return m, nil
+	}
+	// If the position is not an identifier but immediately follows
+	// an identifier or selector period (as is common when
+	// requesting a completion), use the path to the preceding node.
+	return checkMatch(f, pos-1)
+}
+
+// checkMatch checks a single position for a potential identifier.
+func checkMatch(f *ast.File, pos token.Pos) (match, error) {
+	path, _ := astutil.PathEnclosingInterval(f, pos, pos)
+	result := match{}
+	if path == nil {
+		return result, fmt.Errorf("can't find node enclosing position")
+	}
+	switch node := path[0].(type) {
+	case *ast.Ident:
+		result.ident = node
+	case *ast.SelectorExpr:
+		result.ident = node.Sel
+	}
+	if result.ident != nil {
+		for _, n := range path[1:] {
+			if field, ok := n.(*ast.Field); ok {
+				result.wasEmbeddedField = len(field.Names) == 0
+			}
+		}
+	}
+	return result, nil
+}
+
+func trimAST(file *ast.File, pos token.Pos) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if pos < n.Pos() || pos >= n.End() {
+			switch n := n.(type) {
+			case *ast.FuncDecl:
+				n.Body = nil
+			case *ast.BlockStmt:
+				n.List = nil
+			case *ast.CaseClause:
+				n.Body = nil
+			case *ast.CommClause:
+				n.Body = nil
+			case *ast.CompositeLit:
+				// Leave elts in place for [...]T
+				// array literals, because they can
+				// affect the expression's type.
+				if !isEllipsisArray(n.Type) {
+					n.Elts = nil
+				}
+			}
+		}
+		return true
+	})
+}
+
+func isEllipsisArray(n ast.Expr) bool {
+	at, ok := n.(*ast.ArrayType)
+	if !ok {
+		return false
+	}
+	_, ok = at.Len.(*ast.Ellipsis)
+	return ok
+}

--- a/packages.go
+++ b/packages.go
@@ -45,7 +45,6 @@ func godefPackages(cfg *packages.Config, filename string, src []byte, searchpos 
 	if obj == nil && !m.ident.Pos().IsValid() {
 		pkg := lpkgs[0].Imports[m.ident.Name]
 		if pkg != nil && len(pkg.GoFiles) > 0 {
-			fmt.Printf("package was %v\n", pkg.ID)
 			dir := filepath.Dir(pkg.GoFiles[0])
 			obj = types.NewPkgName(token.NoPos, nil, "", types.NewPackage(dir, ""))
 		}

--- a/testdata/b/b.go
+++ b/testdata/b/b.go
@@ -4,6 +4,8 @@ import "github.com/rogpeppe/godef/a"
 
 type S1 struct { //@S1
 	F1 int //@mark(S1F1, "F1")
+	f2 int
+	f3 S2
 	S2     //@godef("S2", S2), mark(S1S2, "S2")
 }
 

--- a/testdata/b/b.go
+++ b/testdata/b/b.go
@@ -6,7 +6,7 @@ type S1 struct { //@S1
 	F1 int //@mark(S1F1, "F1")
 	f2 int
 	f3 S2
-	S2     //@godef("S2", S2), mark(S1S2, "S2")
+	S2 //@godef("S2", S2), mark(S1S2, "S2")
 }
 
 type S2 struct { //@S2

--- a/testdata/print/print.go
+++ b/testdata/print/print.go
@@ -1,0 +1,68 @@
+package print
+
+import (
+	"github.com/rogpeppe/godef/a"
+	"github.com/rogpeppe/godef/b"
+)
+
+type localStruct struct {
+	Exported bool
+	private  bool
+}
+
+func printing() {
+start:
+	var thing localStruct
+	if thing.private {
+		thing.Exported = false
+		goto start //@mark(PrintStart, "start")
+	}
+	a.Stuff()    //@mark(PrintA, "a"),mark(PrintStuff, "Stuff")
+	var _ = b.S1 //@mark(PrintS1, "S1")
+	const c1 = 5
+	if c1 == 2 { //@mark(PrintC1, "c1")
+	}
+
+	/*@
+	godefPrint(PrintA, "json", re`^(|
+		){"filename":".*godef.print.print\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintA, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)import \(a "github\.com/rogpeppe/godef/a"\)\n$`)
+
+	godefPrint(PrintStuff, "json", re`^(|
+		){"filename":".*godef.a.a\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintStuff, "type", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+	godefPrint(PrintStuff, "public", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+	godefPrint(PrintStuff, "all", re`^(|
+		).*godef.a.a\.go:\d+:\d+(\n|
+		).*Stuff func\(\)\n$`)
+
+	godefPrint(PrintC1, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)const c1 (untyped )?int = 5\n$`)
+
+	godefPrint(PrintStart, "type", re`^(|
+		).*godef.print.print\.go:\d+:\d+(\n|
+		)label start\n$`)
+
+	godefPrint(PrintS1, "json", re`^(|
+		){"filename":".*godef.b.b\.go","line":\d+,"column":\d+}\n$`)
+	godefPrint(PrintS1, "type", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct\s*\{\s*F1\s+int[\n;]\s*f2\s+int[\n;]\s*f3\s+S2[\n;]\s*S2\s*\}\n$`)
+	// this succeeds, but lists no fields which seems wrong
+	_godefPrint(PrintS1, "public", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct\s*\{\s*F1\s+int[\n;]\s*f2\s+int[\n;]\s*f3\s+S2[\n;]\s*S2\s*\}\n$`)
+	// the following fails, but it lists F1 twice, once as 'F1 string' which is wrong
+	_godefPrint(PrintS1, "all", re`^(|
+		).*godef.b.b\.go:\d+:\d+(\n|
+		)type S1 struct\s*\{\s*F1\s+int[\n;]\s*f2\s+int[\n;]\s*f3\s+S2[\n;]\s*S2\s*\}\n$`)
+	*/
+}
+

--- a/testdata/print/print.go
+++ b/testdata/print/print.go
@@ -65,4 +65,3 @@ start:
 		)type S1 struct\s*\{\s*F1\s+int[\n;]\s*f2\s+int[\n;]\s*f3\s+S2[\n;]\s*S2\s*\}\n$`)
 	*/
 }
-

--- a/testdata/print/print.go
+++ b/testdata/print/print.go
@@ -1,7 +1,7 @@
 package print
 
 import (
-	"github.com/rogpeppe/godef/a"
+	"github.com/rogpeppe/godef/a" //@mark(PrintImportDir, "rogpeppe")
 	"github.com/rogpeppe/godef/b"
 )
 
@@ -24,6 +24,8 @@ start:
 	}
 
 	/*@
+	godefPrint(PrintImportDir, "json", re`godef[/\\]a\s*$`)
+
 	godefPrint(PrintA, "json", re`^(|
 		){"filename":".*godef.print.print\.go","line":\d+,"column":\d+}\n$`)
 	godefPrint(PrintA, "type", re`^(|


### PR DESCRIPTION
This is a stack of changes, happy to put them all up separately if you prefer.
They add benchmarks (which probably need a bit more work),  profiling support, tests for the output part of godef, rearranges things to enable multiple implementations, and then adds a support for go/packages based on the previous work.
It selects the go/packages implementation automatically if 'go env mod' returns a mod file, and can be forced on or off using the -force-packages flag.
With this set of changes we can switch back to just use this implementation of godef, no need for editors to install my fork separately for module mode.