### PR TITLE
Use test overlay support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,5 @@ module github.com/rogpeppe/godef
 
 require (
 	9fans.net/go v0.0.0-20181112161441-237454027057
-	golang.org/x/tools v0.0.0-20181130195746-895048a75ecf
+	golang.org/x/tools v0.0.0-20181207222222-4c874b978acb
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
 9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
-golang.org/x/tools v0.0.0-20181130195746-895048a75ecf h1:1efYtlcDNt7EL138lS6P4KphZ1KEMWvhFa3FsLbTWEY=
-golang.org/x/tools v0.0.0-20181130195746-895048a75ecf/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181207222222-4c874b978acb h1:YIXCxYolAiiPmVSqA4gVUVcHo8Mi1ivU7ANnK9a63JY=
+golang.org/x/tools v0.0.0-20181207222222-4c874b978acb/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/packages.go
+++ b/packages.go
@@ -18,9 +18,10 @@ func godefPackages(cfg *packages.Config, filename string, src []byte, searchpos 
 	parser, result := parseFile(filename, searchpos)
 	// Load, parse, and type-check the packages named on the command line.
 	if src != nil {
-		cfg.Overlay = map[string][]byte{
-			filename: src,
+		if cfg.Overlay == nil {
+			cfg.Overlay = make(map[string][]byte)
 		}
+		cfg.Overlay[filename] = src
 	}
 	cfg.Mode = packages.LoadSyntax
 	cfg.ParseFile = parser

--- a/testdata/b/c.go
+++ b/testdata/b/c.go
@@ -1,8 +1,3 @@
 package b
 
-// This is the in-editor version of the file.
-// The on-disk version is in c.go.saved.
-
-var _ = S1{ //@godef("S1", S1)
-	F1: 99, //@_godef("F1", S1F1) //disabled, godef cannot resolve struct literal fields yet
-}
+// This is the on-disk version of c.go.

--- a/testdata/b/c.go.overlay
+++ b/testdata/b/c.go.overlay
@@ -1,0 +1,9 @@
+package b
+
+// This is the in-editor version of the file.
+// The on-disk version is in c.go.
+// This file is used as an overlay
+
+var _ = S1{ //@godef("S1", S1)
+	F1: 99, //@_godef("F1", S1F1) //disabled, godef cannot resolve struct literal fields yet
+}

--- a/testdata/b/c.go.saved
+++ b/testdata/b/c.go.saved
@@ -1,7 +1,0 @@
-package b
-
-// This is the on-disk version of c.go, which represents
-// the in-editor version of the file.
-
-}
-


### PR DESCRIPTION
This switches the godef tests to use the improved overlay support in go/packages and the testing framework.