### PR TITLE
Drop the about in README

### DIFF
--- a/README
+++ b/README
@@ -5,5 +5,5 @@ location of the definition of the symbol referred to.
 
 Known limitations:
 
-- it does not understand about "." imports
+- it does not understand "." imports
 - it does not deal well with definitions in tests.


### PR DESCRIPTION
A bit of grammar improvement `about` is not needed here, makes it sound odd.
You would use about if you had an indefinite pronoun such as *anything* in "It does not understand *anything* about...".