### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/go/scanner/errors.go
+++ b/go/scanner/errors.go
@@ -61,7 +61,7 @@ func (e *Error) Error() string {
 // An ErrorList is a (possibly sorted) list of Errors.
 type ErrorList []*Error
 
-// ErrorList implements the sort Interface.
+// implements the sort Interface.
 func (p ErrorList) Len() int      { return len(p) }
 func (p ErrorList) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
@@ -148,7 +148,7 @@ func (h *ErrorVector) GetError(mode int) error {
 	return h.GetErrorList(mode)
 }
 
-// ErrorVector implements the ErrorHandler interface.
+// Error implements the ErrorHandler interface.
 func (h *ErrorVector) Error(pos token.Position, msg string) {
 	h.errors = append(h.errors, &Error{pos, msg})
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._