### PR TITLE
Fall back to path mode when no go.mod is present

### DIFF
--- a/adapt.go
+++ b/adapt.go
@@ -94,7 +94,8 @@ func detectModuleMode(cfg *packages.Config) bool {
 	cmd.Dir = cfg.Dir
 	out, err := cmd.Output()
 	if err == nil {
-		return len(strings.TrimSpace(string(out))) > 0
+		outstr := strings.TrimSpace(string(out))
+		return len(outstr) > 0 && outstr != os.DevNull
 	}
 	// default to non module mode
 	return false


### PR DESCRIPTION
Fixes #124 

Following this change, if godef cannot find a go.mod file for the
current module (that is, if the go env command returns the null device
for gomod), then godef will default to non-module mode rather than failing.